### PR TITLE
Fix RSpec generated worker template indentation

### DIFF
--- a/lib/generators/sidekiq/templates/worker_spec.rb.erb
+++ b/lib/generators/sidekiq/templates/worker_spec.rb.erb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 <% module_namespacing do -%>
 RSpec.describe <%= class_name %>Worker, type: :worker do
-    pending "add some examples to (or delete) #{__FILE__}"
+  pending "add some examples to (or delete) #{__FILE__}"
 end
 <% end -%>


### PR DESCRIPTION
Should be two spaces instead of four. 